### PR TITLE
rename `superAPI` to `endpoint`

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -17,7 +17,7 @@ export default defineConfig({
       { text: "Guide", link: "/guide/getting-started", activeMatch: "/guide" },
       {
         text: "API Reference",
-        link: "/reference/superAPI",
+        link: "/reference/endpoint",
         activeMatch: "/reference",
       },
     ],
@@ -45,7 +45,7 @@ export default defineConfig({
       {
         text: "Reference",
         items: [
-          { text: "superAPI", link: "/reference/superAPI" },
+          { text: "endpoint", link: "/reference/endpoint" },
           { text: "superActions", link: "/reference/superActions" },
         ],
       },

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -27,16 +27,16 @@ We'll begin by making an [endpoint](/guide/terminology.md#api--endpoint) on the 
 
 First, create a `+server.ts` file somewhere inside your routes folder. We'll choose `src/routes/api` this time.
 
-To define an endpoint, use the `superAPI` function. It takes in a path and some actions, and returns a normal SvelteKit request handler that we'll then mount inside a `+server.ts` file.
+To define an endpoint, use the `endpoint` function. It takes in a path and some actions, and returns a normal SvelteKit request handler that we'll then mount inside a `+server.ts` file.
 
-In the `+server.ts` file, give the `superAPI` a path and some action(s), and export its return value as a POST handler like so:
+In the `+server.ts` file, give the `endpoint` a path and some action(s), and export its return value as a POST handler like so:
 
 ```ts
 // src/routes/api/+server.ts
-import { superAPI } from "sveltekit-superactions";
+import { endpoint } from "sveltekit-superactions";
 
-// superAPI returns a sveltekit request handler function.
-export const POST = superAPI({
+// endpoint returns a sveltekit request handler function.
+export const POST = endpoint({
   path: "/api",
   actions: {
     // The first argument is the RequestEvent provided by SvelteKit.
@@ -48,7 +48,7 @@ export const POST = superAPI({
 });
 ```
 
-The `superAPI` function takes in a config object with the following fields:
+The `endpoint` function takes in a config object with the following fields:
 
 ### `path`
 
@@ -62,7 +62,7 @@ This is where you define the functions that the client can call using this endpo
 
 The load function is what tells the client what endpoints and actions are available.
 
-In order to access the endpoint on the client, we need to load the endpoint using `+page.server.ts` or `+layout.server.ts`. Simply import the handler that you created previously using the `superAPI` function, and return its actions like so:
+In order to access the endpoint on the client, we need to load the endpoint using `+page.server.ts` or `+layout.server.ts`. Simply import the handler that you created previously using the `endpoint` function, and return its actions like so:
 
 ```ts
 // src/routes/+page.layout.ts
@@ -125,14 +125,14 @@ In this case the input is a string, to we'll
 
 ```ts
 // src/routes/api/+server.ts
-import { superAPI } from "sveltekit-superactions"; // [!code --]
-import { superAPI, zod } from "sveltekit-superactions"; // [!code ++]
+import { endpoint } from "sveltekit-superactions"; // [!code --]
+import { endpoint, zod } from "sveltekit-superactions"; // [!code ++]
 import { z } from "zod"; // [!code ++]
 
 const greetSchema = z.string() // [!code ++]
 
-// superAPI returns a sveltekit request handler function.
-export const POST = superAPI({
+// endpoint returns a sveltekit request handler function.
+export const POST = endpoint({
   path: "/api",
   actions: {
     // The first argument is the RequestEvent provided by SvelteKit.

--- a/guide/restrictions.md
+++ b/guide/restrictions.md
@@ -12,4 +12,4 @@ Actions cannot have more than 1 argument passed into them. This is mostly becaus
 
 SvelteKit automatically generates a `RequestHandler` for each route, containing type information about the available parameters and the current path.
 
-Superactions is still in an early state, and doesn't yet have support for using this type with the `superAPI` function. This means that actions don't have full type information about the available parameters.
+Superactions is still in an early state, and doesn't yet have support for using this type with the `endpoint` function. This means that actions don't have full type information about the available parameters.

--- a/guide/terminology.md
+++ b/guide/terminology.md
@@ -4,7 +4,7 @@ Some terminology in the documentation is Svelte or SvelteKit-specific, but here 
 
 ## API / Endpoint
 
-API and endpoint in this case mean the same thing: A group of `async` functions called [actions](#actions), defined on the server using the [`superAPI`](/reference/superAPI.md) function.
+API and endpoint in this case mean the same thing: A group of `async` functions called [actions](#actions), defined on the server using the [`endpoint`](/reference/endpoint.md) function.
 
 There are no restrictions to how many APIs/endpoints you can define.
 

--- a/reference/endpoint.md
+++ b/reference/endpoint.md
@@ -1,13 +1,13 @@
-# `superAPI`
+# `endpoint`
 
 Used to build an endpoint that holds one or more action(s), where an action is a function that the client can call like a normal `async` function. It returns a request handler function that can be mounted as a POST handler in a [+server.ts](https://kit.svelte.dev/docs/routing#server) file like so:
 
 ```ts
 // src/routes/.../+server.ts
 
-import { superAPI } from "sveltekit-superactions";
+import { endpoint } from "sveltekit-superactions";
 
-export const POST = superAPI({
+export const POST = endpoint({
   // ...
 });
 ```
@@ -31,7 +31,7 @@ Example:
 ```ts
 // On the server
 
-export const POST = superAPI({
+export const POST = endpoint({
   // ...
   actions: {
     myFunction: async () => {}, // [!code highlight]

--- a/validation/joi.md
+++ b/validation/joi.md
@@ -12,7 +12,7 @@ Import the `joi` helper function and wrap the action you want to validate with i
 import { joi } from "sveltekit-superactions";
 import Joi from "joi";
 
-export const POST = superAPI({
+export const POST = endpoint({
   // ... other config
   actions: {
     // body must be a non-empty string, otherwise the request fails

--- a/validation/zod.md
+++ b/validation/zod.md
@@ -12,7 +12,7 @@ Import the `zod` helper function and wrap the action you want to validate with i
 import { zod } from "sveltekit-superactions";
 import { z } from "zod";
 
-export const POST = superAPI({
+export const POST = endpoint({
   // ... other config
   actions: {
     // body must be a non-empty string, otherwise the request fails


### PR DESCRIPTION
sync with `v0.4.0` release